### PR TITLE
Add Python‑Rust plots and fully documented Julia code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 n_body_problem_3D/__pycache__/solver.cpython-311.pyc
 n_body_problem_3D_gif_version/__pycache__/solver.cpython-311.pyc
+*.csv
+*.png
+three_body_rust_simulation

--- a/README.md
+++ b/README.md
@@ -2,3 +2,80 @@
 ## File origin
 - n_body_problem_3D --> https://github.com/Younes-Toumi/Youtube-Channel/tree/main/Simulation%20with%20Python/3%20Body%20Problem
 - n_body_problem_3D_gif_version --> https://github.com/Younes-Toumi/Modeling-and-Simulating-Complex-Chaotic-Systems/tree/main/N-Body-Problem
+
+## Julia Simulation
+A simple Julia implementation of the 3-body problem is provided in `three_body_julia_simulation.jl`. The script uses `Plots` and `DelimitedFiles` from the Julia standard ecosystem.
+
+### Requirements
+- Julia 1.9 or later
+- `Plots` package (`] add Plots` from the Julia REPL)
+
+### Running
+Execute the simulation with
+
+```bash
+julia three_body_julia_simulation.jl
+```
+
+The script writes `julia_trajectories.csv` and creates `julia_trajectories.png` showing the three trajectories.
+
+To compare with the Python version run
+
+```bash
+python simulate_python.py
+```
+
+Running the Python script creates `python_trajectories.csv` and a PNG
+`python_trajectories.png` of the Python paths. If Rust or Julia data is
+present, additional plots will be produced:
+
+- `python_rust_comparison.png` – Python vs. Rust
+- `comparison.png` – overlay of Python, Rust and Julia (if available)
+
+These images appear in the repository directory.
+
+### Installation notes
+On some minimal environments `apt-get install julia` returns `Package julia has no installation candidate`.
+To install Julia you can add the official repository:
+
+```bash
+sudo apt-get update
+sudo apt-get install wget ca-certificates
+wget -qO- https://julialang-s3.julialang.org/bin/linux/debian/archive.key | sudo tee /etc/apt/trusted.gpg.d/julia.asc
+sudo sh -c "echo 'deb https://julialang-s3.julialang.org/bin/linux/ubuntu $(lsb_release -cs) main' > /etc/apt/sources.list.d/julia.list"
+sudo apt-get update
+sudo apt-get install julia
+```
+
+Or manually download the tarball if network access is allowed:
+
+```bash
+wget https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.2-linux-x86_64.tar.gz
+ tar xzf julia-1.10.2-linux-x86_64.tar.gz
+ sudo mv julia-1.10.2 /opt/julia
+ sudo ln -s /opt/julia/bin/julia /usr/local/bin/julia
+```
+
+Make sure Python dependencies are installed before running `simulate_python.py`:
+
+```bash
+pip install numpy matplotlib
+```
+
+## Rust Simulation
+A minimal Rust version is available in `three_body_rust_simulation.rs`.
+
+### Requirements
+- Rust toolchain (rustc and cargo)
+
+### Running
+Compile and run the program with
+
+```bash
+rustc three_body_rust_simulation.rs
+./three_body_rust_simulation
+```
+
+The program writes `rust_trajectories.csv`. Run `python simulate_python.py`
+afterwards to create `python_rust_comparison.png` and the full
+`comparison.png`.

--- a/simulate_python.py
+++ b/simulate_python.py
@@ -1,0 +1,129 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+
+# Gravitational constant
+G = 6.67430e-11
+
+# All bodies have the same mass
+masses = np.array([5.0e24, 5.0e24, 5.0e24])
+
+# Initial positions forming an equilateral triangle (meters)
+initial_positions = np.array([
+    [0.0, 0.0],
+    [-0.5e11, np.sqrt(3) * 0.5e11],
+    [0.5e11, np.sqrt(3) * 0.5e11],
+], dtype=float)
+
+# Tangential velocities for a rotating configuration (m/s)
+v0 = np.sqrt(G * masses[0] / (1e11 * np.sqrt(3)))
+initial_velocities = np.array([
+    [0.0, v0],
+    [-v0 * np.sqrt(3)/2, -v0 / 2],
+    [v0 * np.sqrt(3)/2, -v0 / 2],
+], dtype=float)
+
+# Integration parameters
+TIME_STEP = 1e5  # seconds
+NUM_STEPS = 300  # number of iterations
+
+# Prepare arrays for positions and velocities
+positions = initial_positions.copy()
+velocities = initial_velocities.copy()
+trajectories = np.zeros((NUM_STEPS+1, 6))
+trajectories[0] = positions.flatten()
+
+# Compute gravitational force between two bodies
+
+def gravitational_force(m1, m2, pos1, pos2):
+    r = pos2 - pos1
+    dist = np.linalg.norm(r)
+    if dist == 0:
+        return np.zeros(2)
+    force_mag = G * m1 * m2 / dist**2
+    return force_mag * r / dist
+
+# Perform the integration using a simple Euler scheme
+for step in range(1, NUM_STEPS+1):
+    forces = np.zeros((3, 2))
+    for i in range(3):
+        for j in range(i+1, 3):
+            f = gravitational_force(masses[i], masses[j], positions[i], positions[j])
+            forces[i] += f
+            forces[j] -= f
+    for i in range(3):
+        accel = forces[i] / masses[i]
+        velocities[i] += accel * TIME_STEP
+        positions[i] += velocities[i] * TIME_STEP
+    trajectories[step] = positions.flatten()
+
+# Save results for later comparison
+np.savetxt('python_trajectories.csv', trajectories, delimiter=',')
+
+# Load Julia results if present and compute difference
+julia_data = None
+if os.path.exists('julia_trajectories.csv'):
+    julia_data = np.loadtxt('julia_trajectories.csv', delimiter=',')
+
+rust_data = None
+if os.path.exists('rust_trajectories.csv'):
+    rust_data = np.loadtxt('rust_trajectories.csv', delimiter=',')
+
+labels = ['Body 1', 'Body 2', 'Body 3']
+colors = ['tab:blue', 'tab:orange', 'tab:green']
+
+# Plot Python trajectories only
+plt.figure()
+for i in range(3):
+    x = trajectories[:, 2*i]
+    y = trajectories[:, 2*i+1]
+    plt.plot(x, y, color=colors[i], label=f'Python {labels[i]}')
+plt.xlabel('x (m)')
+plt.ylabel('y (m)')
+plt.legend()
+plt.axis('equal')
+plt.tight_layout()
+plt.savefig('python_trajectories.png')
+
+# Plot comparison of available implementations
+plt.figure()
+for i in range(3):
+    x = trajectories[:, 2*i]
+    y = trajectories[:, 2*i+1]
+    plt.plot(x, y, color=colors[i], label=f'Python {labels[i]}')
+    if julia_data is not None:
+        plt.plot(julia_data[:, 2*i], julia_data[:, 2*i+1], '--', color=colors[i], label=f'Julia {labels[i]}')
+    if rust_data is not None:
+        plt.plot(rust_data[:, 2*i], rust_data[:, 2*i+1], ':', color=colors[i], label=f'Rust {labels[i]}')
+plt.xlabel('x (m)')
+plt.ylabel('y (m)')
+plt.legend()
+plt.axis('equal')
+plt.tight_layout()
+plt.savefig('comparison.png')
+
+# Plot Python vs Rust only if rust data is present
+if rust_data is not None:
+    plt.figure()
+    for i in range(3):
+        plt.plot(trajectories[:, 2*i], trajectories[:, 2*i+1], color=colors[i], label=f'Python {labels[i]}')
+        plt.plot(rust_data[:, 2*i], rust_data[:, 2*i+1], ':', color=colors[i], label=f'Rust {labels[i]}')
+    plt.xlabel('x (m)')
+    plt.ylabel('y (m)')
+    plt.legend()
+    plt.axis('equal')
+    plt.tight_layout()
+    plt.savefig('python_rust_comparison.png')
+
+# Print final position difference if Julia data available
+if julia_data is not None:
+    diff = np.linalg.norm(trajectories[-1] - julia_data[-1])
+    print(f'Final position vector difference Python vs Julia: {diff:.3e} m')
+else:
+    print('Julia results not found. Run the Julia script before comparison.')
+
+if rust_data is not None:
+    diff_rust = np.linalg.norm(trajectories[-1] - rust_data[-1])
+    print(f'Final position vector difference Python vs Rust: {diff_rust:.3e} m')
+else:
+    print('Rust results not found. Run the Rust program before comparison.')

--- a/three_body_julia_simulation.jl
+++ b/three_body_julia_simulation.jl
@@ -1,0 +1,82 @@
+# Load plotting and file I/O modules
+using Plots              # generate PNG output
+using DelimitedFiles     # write CSV files
+
+# Gravitational constant used in the simulation
+const G = 6.67430e-11  # [m^3 kg^-1 s^-2]
+
+# Masses of the three bodies (kg)
+masses = [5.0e24, 5.0e24, 5.0e24]  # identical masses
+
+# Initial positions in meters (forming an equilateral triangle)
+initial_positions = [
+    0.0      0.0;                             # body 1
+    -0.5e11  sqrt(3) * 0.5e11;               # body 2
+    0.5e11   sqrt(3) * 0.5e11;               # body 3
+]
+
+# Initial velocities tangential to the positions for rotation (m/s)
+v0 = sqrt(G * masses[1] / (1e11 * sqrt(3)))  # base magnitude
+initial_velocities = [
+    0.0               v0;                    # body 1 velocity
+    -v0 * sqrt(3)/2  -v0/2;                  # body 2 velocity
+    v0 * sqrt(3)/2   -v0/2;                  # body 3 velocity
+]
+
+# Integration parameters
+const TIME_STEP = 1e5      # seconds per step
+const NUM_STEPS = 300      # number of iterations
+
+# Current state arrays (positions and velocities)
+positions = deepcopy(initial_positions)   # mutable copy of positions
+velocities = deepcopy(initial_velocities) # mutable copy of velocities
+
+# Storage for trajectories (each row: x1,y1,x2,y2,x3,y3)
+trajectories = zeros(NUM_STEPS + 1, 6)
+trajectories[1, :] = vec(positions)'  # store initial state
+
+# Function to compute gravitational force between two bodies
+function gravitational_force(m1, m2, pos1, pos2)
+    r = pos2 .- pos1                   # displacement vector
+    dist = norm(r)                     # distance between bodies
+    if dist == 0.0                     # avoid division by zero
+        return zeros(2)
+    end
+    force_mag = G * m1 * m2 / dist^2   # Newton's law of gravitation
+    return force_mag .* r ./ dist      # force vector
+end
+
+# Main integration loop using a simple Euler scheme
+for step in 1:NUM_STEPS
+    forces = zeros(3, 2)                       # reset force accumulators
+    for i in 1:3                               # loop over body pairs
+        for j in i+1:3
+            f = gravitational_force(masses[i], masses[j], positions[i, :], positions[j, :])
+            forces[i, :] .+= f                 # apply equal and opposite forces
+            forces[j, :] .-= f
+        end
+    end
+    for i in 1:3
+        acceleration = forces[i, :] ./ masses[i]
+        velocities[i, :] .+= acceleration .* TIME_STEP
+        positions[i, :] .+= velocities[i, :] .* TIME_STEP
+    end
+    trajectories[step + 1, :] = vec(positions)' # store state each step
+end
+
+# Save trajectories for comparison with Python version
+writedlm("julia_trajectories.csv", trajectories, ',')  # CSV output
+
+# Plot the paths of the three bodies
+plt = plot()                               # initialize the plot
+colors = [:blue, :orange, :green]          # one color per body
+for i in 1:3
+    x = trajectories[:, 2*(i-1)+1]         # extract x positions
+    y = trajectories[:, 2*(i-1)+2]         # extract y positions
+    plot!(plt, x, y, color=colors[i], label="Body $i")
+end
+xlabel!(plt, "x (m)")
+ylabel!(plt, "y (m)")
+plot!(plt, aspect_ratio = :equal)          # keep aspect ratio square
+savefig(plt, "julia_trajectories.png")    # write PNG image
+

--- a/three_body_rust_simulation.rs
+++ b/three_body_rust_simulation.rs
@@ -1,0 +1,76 @@
+// Simple 3-body simulation in Rust using Euler integration
+// Requires Rust 1.56+ to compile with `rustc three_body_rust_simulation.rs`
+// Outputs trajectories to rust_trajectories.csv for comparison
+
+use std::fs::File;
+use std::io::Write;
+
+const G: f64 = 6.67430e-11; // gravitational constant
+const MASSES: [f64; 3] = [5.0e24, 5.0e24, 5.0e24];
+const TIME_STEP: f64 = 1e5; // seconds
+const NUM_STEPS: usize = 300; // integration iterations
+
+fn main() {
+    // Initial positions (equilateral triangle)
+    let mut positions = [
+        [0.0, 0.0],
+        [-0.5e11, (3f64).sqrt() * 0.5e11],
+        [0.5e11, (3f64).sqrt() * 0.5e11],
+    ];
+
+    // Tangential velocities for a rotating setup
+    let v0 = (G * MASSES[0] / (1e11 * (3f64).sqrt())).sqrt();
+    let mut velocities = [
+        [0.0, v0],
+        [-v0 * (3f64).sqrt() / 2.0, -v0 / 2.0],
+        [v0 * (3f64).sqrt() / 2.0, -v0 / 2.0],
+    ];
+
+    // Storage for positions at each step
+    let mut trajectories = vec![[0.0; 6]; NUM_STEPS + 1];
+    for i in 0..3 {
+        trajectories[0][2 * i] = positions[i][0];
+        trajectories[0][2 * i + 1] = positions[i][1];
+    }
+
+    // Main integration loop
+    for step in 1..=NUM_STEPS {
+        let mut forces = [[0.0f64; 2]; 3];
+        // Compute pairwise forces
+        for i in 0..3 {
+            for j in (i + 1)..3 {
+                let dx = positions[j][0] - positions[i][0];
+                let dy = positions[j][1] - positions[i][1];
+                let dist = (dx * dx + dy * dy).sqrt();
+                if dist != 0.0 {
+                    let mag = G * MASSES[i] * MASSES[j] / dist.powi(2);
+                    let fx = mag * dx / dist;
+                    let fy = mag * dy / dist;
+                    forces[i][0] += fx;
+                    forces[i][1] += fy;
+                    forces[j][0] -= fx;
+                    forces[j][1] -= fy;
+                }
+            }
+        }
+        // Update velocities and positions
+        for i in 0..3 {
+            let ax = forces[i][0] / MASSES[i];
+            let ay = forces[i][1] / MASSES[i];
+            velocities[i][0] += ax * TIME_STEP;
+            velocities[i][1] += ay * TIME_STEP;
+            positions[i][0] += velocities[i][0] * TIME_STEP;
+            positions[i][1] += velocities[i][1] * TIME_STEP;
+            trajectories[step][2 * i] = positions[i][0];
+            trajectories[step][2 * i + 1] = positions[i][1];
+        }
+    }
+
+    // Write CSV output for comparison
+    let mut file = File::create("rust_trajectories.csv").expect("create file");
+    for row in trajectories {
+        writeln!(file, "{},{},{},{},{},{}", row[0], row[1], row[2], row[3], row[4], row[5])
+            .expect("write csv");
+    }
+}
+


### PR DESCRIPTION
## Summary
- ignore simulation outputs
- expand `simulate_python.py` to save Python-only and Python-vs-Rust plots
- document how to use the Rust data in the README
- comment every line of the Julia implementation

## Testing
- `pip install numpy matplotlib`
- `rustc three_body_rust_simulation.rs -O`
- `./three_body_rust_simulation`
- `python simulate_python.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff40dce2c8322925440c80ca82c0c